### PR TITLE
FIX The extrafield factor_depot must be editable when invoice is vali…

### DIFF
--- a/core/modules/modFactor.class.php
+++ b/core/modules/modFactor.class.php
@@ -293,7 +293,7 @@ class modFactor extends DolibarrModules
         $res = $extrafields->addExtraField('fk_soc_factor', 'Fournisseur du factor', 'sellist', 0, '', 'societe',0, 0,'',  unserialize('a:1:{s:7:"options";a:1:{s:32:"societe:nom:rowid::fournisseur=1";N;}}') ); //Ne peut prendre de order by
 		$res = $extrafields->addExtraField('factor_suivi', 'Utiliser le factor', 'select', 0, '', 'societe',0, 0,'', array("options"=> array(2=>'Non',1=>'Oui')));
 		
-		$res = $extrafields->addExtraField('factor_depot', 'Déposé au factor', 'select', 0, '', 'facture',0, 0,'', array("options"=> array(2=>'A déposer',1=>'Oui')));
+		$res = $extrafields->addExtraField('factor_depot', 'Déposé au factor', 'select', 0, '', 'facture',0, 0,'', array("options"=> array(2=>'A déposer',1=>'Oui')), 1);
 
 		$result=$this->_load_tables('/factor/sql/');
 


### PR DESCRIPTION
…dated

The extrafield is create without attribute "edit whatever is status".
So when invoice is validated, it is no more possible to set the field factor_depot forcing user to unvalidate the invoice and then validate it. This is bad because we update this field in most cases after having validated the invoice.